### PR TITLE
Upgrade Docker image to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER Azavea <systems@azavea.com>
 
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     libgeos-dev \
     libproj-dev \
     libspatialite-dev \
-    libspatialite5 \
+    libspatialite7 \
     spatialite-bin \
     libibnetdisc-dev \
     wget
@@ -49,4 +49,4 @@ RUN wget -qO- https://github.com/dtarb/TauDEM/archive/v${TAUDEM_VERSION}.tar.gz 
 RUN ln -s /usr/src/TauDEM-${TAUDEM_VERSION} /opt/taudem
 ENV PATH /opt/taudem:$PATH
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade "pip<21"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # docker-taudem
 
-[![Travis CI](https://api.travis-ci.org/WikiWatershed/docker-taudem.svg "Build Status on Travis CI")](https://travis-ci.org/WikiWatershed/docker-taudem/)
 [![Docker Repository on Quay.io](https://quay.io/repository/wikiwatershed/taudem/status "Docker Repository on Quay.io")](https://quay.io/repository/wikiwatershed/taudem)
 [![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/wikiwatershed/docker-taudem/blob/develop/LICENSE)
 
@@ -23,7 +22,5 @@ $ git flow release start 0.1.0
 $ vim CHANGELOG.md
 $ vim Dockerfile
 $ git commit -m "0.1.0"
-$ git flow release publish 0.1.0
-$ git flow release finish 0.1.0
-$ git push --tags
+$ git flow release finish -p 0.1.0
 ```

--- a/scripts/console.sh
+++ b/scripts/console.sh
@@ -4,4 +4,9 @@ set -ex
 
 ARGS=$*
 
-docker run --rm -ti docker-taudem $ARGS
+if [[ -z $CI ]]; then
+	docker run --rm -ti docker-taudem $ARGS
+else
+	# Run in non-interactive mode in CI
+	docker run --rm docker-taudem $ARGS
+fi


### PR DESCRIPTION
## Overview

This is necessary to upgrade to the latest Python 2.7, so we can build images in the new Docker Image format.

Closes #1 