### PR TITLE
Publish to GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,52 @@
 name: release
 
 on:
-    push:
-      tags: "*"
+  push:
+    branches: [ tt/5/switch-to-ghcr ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: taudem
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@v4
+  release:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-            - name: Set SHA_TAG
-              run: |
-                echo "SHA_TAG=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Setup Docker Buildx
-              uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-            - name: Login to Quay
-              uses: docker/login-action@v3
-              with:
-                registry: quay.io
-                username: ${{ secrets.QUAY_USERNAME }}
-                password: ${{ secrets.QUAY_PASSWORD }}
-
-            - name: Build and push
-              uses: docker/build-push-action@v6
-              with:
-                push: true
-                tags: |
-                  quay.io/wikiwatershed/taudem:${SHA_TAG}
-                  quay.io/wikiwatershed/taudem:${{ github.ref_name }}
-                  quay.io/wikiwatershed/taudem:latest
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: taudem
+  IMAGE_NAME: WikiWatershed/taudem
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   push:
-    branches: [ tt/5/switch-to-ghcr ]
+    tags: "*"
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:16.04
+LABEL org.opencontainers.image.source="https://github.com/WikiWatershed/docker-taudem"
 
 MAINTAINER Azavea <systems@azavea.com>
 


### PR DESCRIPTION
## Overview

The WikiWatershed Quay organization is old and unmaintained. It is much better to have relevant images available on GitHub under the WikiWatershed organization itself, for ease of use and centralization of resources.

Closes #5 

### Demo

https://github.com/WikiWatershed/docker-taudem/actions/runs/9911599109

https://github.com/WikiWatershed/docker-taudem/pkgs/container/taudem